### PR TITLE
Feat/Refactor: replace LitJSON with System.Text.Json

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -204,14 +204,6 @@ Before following the steps below, please ensure that the two JSON files mentione
 8. Click this button to export files (if a target usage is selected, export path is shown below button).
 9. Click this button to save data description file to "JsonHome".
 
-## Third-party dependencies
-
-### Dependencies of TableCraft.Core 
-
-* [LitJson](https://github.com/LitJSON/litjson): JSON serialization and deserialization 
-* [Mono.TextTemplating](https://github.com/Microsoft/t4): T4 Templating language engine available for .NET 6.0 
-* [p4api.net](https://www.nuget.org/packages/p4api.net): Supports Perforce version control 
-
 ## License
 
 [MIT](http://opensource.org/licenses/MIT)

--- a/README.md
+++ b/README.md
@@ -209,14 +209,6 @@ namespace Foo {
 8. 点击此按钮导出文件（如选择单一途径，导出路径显示按钮下方）
 9. 点击此按钮将数据描述文件保存至"JsonHome"
 
-## 第三方依赖
-
-### TableCraft.Core 依赖
-
-* [LitJson](https://github.com/LitJSON/litjson)：json序列化与反序列化
-* [Mono.TextTemplating](https://github.com/mono/t4)：.NET 6.0 可用的T4 Templating 语言引擎
-* [p4api.net](https://www.nuget.org/packages/p4api.net)：支持Perforce版本控制
-
 ## License
 
 [MIT](http://opensource.org/licenses/MIT)

--- a/TableCraft.Core/Source/CsvSource.cs
+++ b/TableCraft.Core/Source/CsvSource.cs
@@ -24,11 +24,11 @@ public class CsvSource : IDataSource
         /// <summary>
         /// Read Attribute name from header line, this is a must-have
         /// </summary>
-        public int HeaderLineIndex;
+        public int HeaderLineIndex { get; set; }
         /// <summary>
         /// -1 if no comment line
         /// </summary>
-        public int CommentLineIndex = -1;
+        public int CommentLineIndex { get; set; } = -1;
 
         public Configuration Fix()
         {

--- a/TableCraft.Core/TableCraft.Core.csproj
+++ b/TableCraft.Core/TableCraft.Core.csproj
@@ -7,7 +7,7 @@
     <RepositoryUrl>https://github.com/kalulas/TableCraft.Core</RepositoryUrl>
     <PackageReadmeFile>README.en.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <Version>1.0.2</Version>
+    <Version>1.1.0</Version>
     <PackageIcon>crafting-table-128.png</PackageIcon>
     <PackageTags>code-generation</PackageTags>
     <PackageReleaseNotes># Changelog
@@ -23,6 +23,8 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### 1.0.1 (2023-07-12)
 </PackageReleaseNotes>
+    <AssemblyVersion>1.1.0</AssemblyVersion>
+    <FileVersion>1.1.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TableCraft.Core/TableCraft.Core.csproj
+++ b/TableCraft.Core/TableCraft.Core.csproj
@@ -26,7 +26,6 @@ All notable changes to this project will be documented in this file. See [standa
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LitJson" Version="0.17.0" />
     <PackageReference Include="Mono.TextTemplating" Version="3.0.0" />
     <PackageReference Include="p4api.net" Version="2025.1.277.3624" />
   </ItemGroup>

--- a/TableCraft.Editor/Models/ConfigFileElement.cs
+++ b/TableCraft.Editor/Models/ConfigFileElement.cs
@@ -5,19 +5,12 @@ namespace TableCraft.Editor.Models;
 
 /// <summary>
 /// <para> File information for an existed config file(data source) </para>
-/// <para> For LitJson reflection used </para>
+/// <para> Compatible with System.Text.Json serialization </para>
 /// </summary>
 public class ConfigFileElement : IComparable<ConfigFileElement>
 {
-    // public / CamelCase for LitJson reflection
-    public readonly string ConfigFileRelativePath;
-    public string JsonFileRelativePath;
-
-    public ConfigFileElement()
-    {
-        ConfigFileRelativePath = string.Empty;
-        JsonFileRelativePath = string.Empty;
-    }
+    public string ConfigFileRelativePath { get; init; }
+    public string JsonFileRelativePath { get; set; }
 
     public ConfigFileElement(string configFileRelativePath, string jsonFileRelativePath)
     {

--- a/TableCraft.Editor/TableCraft.Editor.csproj
+++ b/TableCraft.Editor/TableCraft.Editor.csproj
@@ -6,9 +6,9 @@
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Assets\CraftingTable_256.ico</ApplicationIcon>
-    <Version>1.4.2</Version>
-    <AssemblyVersion>1.4.2</AssemblyVersion>
-    <FileVersion>1.4.2</FileVersion>
+    <Version>1.4.3</Version>
+    <AssemblyVersion>1.4.3</AssemblyVersion>
+    <FileVersion>1.4.3</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request migrates the codebase from the third-party `LitJson` library to the built-in `System.Text.Json` and `System.Text.Json.Nodes` libraries for JSON parsing and serialization. The changes touch both the configuration loading and the JSON decorator logic, replacing all usages of `LitJson` types and APIs with their `System.Text.Json` equivalents. Additionally, the documentation is updated to remove references to the `LitJson` dependency.

**Migration from LitJson to System.Text.Json:**

* Replaced all `LitJson` types (`JsonData`, `JsonMapper`) with `System.Text.Json` and `System.Text.Json.Nodes` types (`JsonObject`, `JsonArray`, `JsonNode`, `JsonSerializer`) throughout `Configuration.cs` and `JsonDecorator.cs`. This includes updates to JSON reading, writing, and object deserialization logic. [[1]](diffhunk://#diff-5b74e12c8462304953e6dfd0235436674d0993683d37b97c0ff436b1e9c21b0fL6-R7) [[2]](diffhunk://#diff-5b74e12c8462304953e6dfd0235436674d0993683d37b97c0ff436b1e9c21b0fL97-R111) [[3]](diffhunk://#diff-5b74e12c8462304953e6dfd0235436674d0993683d37b97c0ff436b1e9c21b0fL121-R126) [[4]](diffhunk://#diff-5b74e12c8462304953e6dfd0235436674d0993683d37b97c0ff436b1e9c21b0fL131-R164) [[5]](diffhunk://#diff-5b74e12c8462304953e6dfd0235436674d0993683d37b97c0ff436b1e9c21b0fL176-R229) [[6]](diffhunk://#diff-5b74e12c8462304953e6dfd0235436674d0993683d37b97c0ff436b1e9c21b0fL221-R263) [[7]](diffhunk://#diff-2f90afc4a5eae0cda7c70b82dd9b2f9655dcd11972925a268153bd337c650bc3L13-R14) [[8]](diffhunk://#diff-2f90afc4a5eae0cda7c70b82dd9b2f9655dcd11972925a268153bd337c650bc3L54-R72) [[9]](diffhunk://#diff-2f90afc4a5eae0cda7c70b82dd9b2f9655dcd11972925a268153bd337c650bc3L71-R188) [[10]](diffhunk://#diff-2f90afc4a5eae0cda7c70b82dd9b2f9655dcd11972925a268153bd337c650bc3L167-R247)

* Refactored private helper methods in `Configuration.cs` and `JsonDecorator.cs` to use the new JSON APIs, including methods for reading string arrays, adding config usage types/groups, and decorating config attributes and usage. [[1]](diffhunk://#diff-5b74e12c8462304953e6dfd0235436674d0993683d37b97c0ff436b1e9c21b0fL97-R111) [[2]](diffhunk://#diff-5b74e12c8462304953e6dfd0235436674d0993683d37b97c0ff436b1e9c21b0fL131-R164) [[3]](diffhunk://#diff-2f90afc4a5eae0cda7c70b82dd9b2f9655dcd11972925a268153bd337c650bc3L54-R72) [[4]](diffhunk://#diff-2f90afc4a5eae0cda7c70b82dd9b2f9655dcd11972925a268153bd337c650bc3L71-R188) [[5]](diffhunk://#diff-2f90afc4a5eae0cda7c70b82dd9b2f9655dcd11972925a268153bd337c650bc3L167-R247)

**Documentation updates:**

* Removed references to `LitJson` from both the English and Chinese `README` files, as it is no longer a dependency. [[1]](diffhunk://#diff-b4f47ddd2e9baf4f63a8b1c7adb79cc6caabfe2958e82d73d7b80d1468075213L207-L214) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L212-L219)

**Improvements and error handling:**

* Improved error handling and type safety when parsing and deserializing JSON, including checks for nulls and type mismatches, with appropriate logging for configuration and decorator loading failures. [[1]](diffhunk://#diff-5b74e12c8462304953e6dfd0235436674d0993683d37b97c0ff436b1e9c21b0fL176-R229) [[2]](diffhunk://#diff-2f90afc4a5eae0cda7c70b82dd9b2f9655dcd11972925a268153bd337c650bc3L167-R247)

* Rewrote the attribute-to-JSON serialization logic to use `System.Text.Json.Nodes.JsonObject` and `JsonArray`, replacing the previous manual writing with `JsonWriter`.

These updates modernize the codebase by leveraging the standard .NET JSON library, reducing external dependencies, and improving maintainability and reliability.