### PR TITLE
Refactor/rework appsettings

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -160,7 +160,7 @@ To use the runtime library TableCraft.Core, you need to configure the `libenv.js
 
 #### appsettings.json
 
-`appsettings.json` configures some important directory paths and also saves user information related to version control.
+`appsettings.json` configures some important directory paths.
 
 ```jsonc
 {
@@ -171,16 +171,17 @@ To use the runtime library TableCraft.Core, you need to configure the `libenv.js
     // Export directory
     "ExportPath":{
         "usage0":""
-     },
-     // Perforce version control related information. No need to manually configure here, just edit and save in the application.
-    "P4Config":{
-        "P4PORT":"",
-        "P4USER":"",
-        "P4CLIENT":"",
-        "P4PASSWDBASE64":""
-    }
+     }
 }
 ```
+
+#### Perforce Version Control Configuration
+
+Perforce version control related information is now stored in the user configuration directory, no manual editing of configuration files is required. Configuration location:
+- Windows: `%APPDATA%\TableCraft\p4config.json`
+- macOS/Linux: `~/.config/TableCraft/p4config.json`
+
+You can configure Perforce connection information in the application's settings interface, and the configuration will be automatically saved to the user directory.
 
 ## Usage of TableCraft.Editor
 

--- a/README.en.md
+++ b/README.en.md
@@ -1,5 +1,9 @@
 # TableCraft
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+![Build](https://img.shields.io/github/actions/workflow/status/kalulas/TableCraft/dotnet.yml?branch=master)
+[![ReleaseDate](https://img.shields.io/github/release-date/kalulas/TableCraft)](https://github.com/kalulas/TableCraft/releases)
+[![Release](https://img.shields.io/github/v/release/kalulas/TableCraft)](https://github.com/kalulas/TableCraft/releases)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # TableCraft
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+![Build](https://img.shields.io/github/actions/workflow/status/kalulas/TableCraft/dotnet.yml?branch=master)
+[![ReleaseDate](https://img.shields.io/github/release-date/kalulas/TableCraft)](https://github.com/kalulas/TableCraft/releases)
+[![Release](https://img.shields.io/github/v/release/kalulas/TableCraft)](https://github.com/kalulas/TableCraft/releases)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 
 [README.en.md](README.en.md)

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ namespace Foo {
 
 #### appsettings.json
 
-`appsettings.json`中配置了一些重要的文件目录，也用于保存版本控制相关的用户信息
+`appsettings.json`中配置了一些重要的文件目录
 
 ```jsonc
 {
@@ -173,16 +173,17 @@ namespace Foo {
     // 生成目录
     "ExportPath": {
         "usage0": ""
-    },
-    // Perforce版本控制相关信息，不需要在此处手动配置，在应用内编辑后进行保存即可
-    "P4Config": {
-        "P4PORT": "",
-        "P4USER": "",
-        "P4CLIENT": "",
-        "P4PASSWDBASE64": ""
     }
 }
 ```
+
+#### Perforce 版本控制配置
+
+Perforce 版本控制相关信息现在存储在用户配置目录中，无需手动编辑配置文件。配置位置：
+- Windows: `%APPDATA%\TableCraft\p4config.json`
+- macOS/Linux: `~/.config/TableCraft/p4config.json`
+
+你可以在应用内的设置界面中配置 Perforce 连接信息，配置将自动保存到用户目录中。
 
 ## TableCraft.Editor使用方式
 

--- a/TableCraft.Core/VersionControl/PerforceUserConfig.cs
+++ b/TableCraft.Core/VersionControl/PerforceUserConfig.cs
@@ -6,6 +6,7 @@
 #endregion
 
 using System;
+using System.Text.Json.Serialization;
 
 namespace TableCraft.Core.VersionControl;
 
@@ -16,6 +17,7 @@ public class PerforceUserConfig
     public string P4CLIENT { get; set; }
     public string P4PASSWDBASE64 { get; set; }
 
+    [JsonIgnore]
     public string P4Passwd { get; private set; } = string.Empty;
 
     public bool IsReady()

--- a/TableCraft.Editor/App.axaml.cs
+++ b/TableCraft.Editor/App.axaml.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
+using Microsoft.Extensions.DependencyInjection;
 using TableCraft.Editor.Services;
 using TableCraft.Editor.ViewModels;
 using TableCraft.Editor.Views;
@@ -51,7 +52,7 @@ public partial class App : Application
 
     private static void LoadAndRegisterVersionControl()
     {
-        var versionControlConfig = Program.GetVersionControlConfig();
+        var versionControlConfig = Program.Host.Services.GetRequiredService<IP4ConfigManager>().GetVersionControlConfig();
         if (!versionControlConfig.IsReady())
         {
             Log.Information("[App.LoadAndRegisterVersionControl] perforce config not ready, exit");

--- a/TableCraft.Editor/App.axaml.cs
+++ b/TableCraft.Editor/App.axaml.cs
@@ -35,14 +35,14 @@ public partial class App : Application
             var listJsonFilePath = AppContext.BaseDirectory + Program.ListJsonFilename;
             if (!File.Exists(listJsonFilePath))
             {
-                throw new FileNotFoundException(listJsonFilePath + " not found, construct database failed");
+                throw new FileNotFoundException(listJsonFilePath + " not found, construct config file registry failed");
             }
 
-            var db = new FakeDatabase(listJsonFilePath);
+            var configFileRegistry = new ConfigFileRegistry(listJsonFilePath);
 
             desktop.MainWindow = new MainWindow
             {
-                DataContext = new MainWindowViewModel(db),
+                DataContext = new MainWindowViewModel(configFileRegistry),
             };
         }
 

--- a/TableCraft.Editor/Models/AppSettings.cs
+++ b/TableCraft.Editor/Models/AppSettings.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace TableCraft.Editor.Models;
+
+/// <summary>
+/// Strongly typed configuration model for appsettings.json
+/// </summary>
+public class AppSettings
+{
+    /// <summary>
+    /// Common root directory of configuration files for reading configuration files
+    /// </summary>
+    public string ConfigHomePath { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Common root directory of configuration description files for saving description files
+    /// </summary>
+    public string JsonHomePath { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Export directories for different usage types
+    /// </summary>
+    public Dictionary<string, string> ExportPath { get; set; } = new();
+    
+    /// <summary>
+    /// Fallback export path when specific usage is not configured
+    /// </summary>
+    public static string FallbackCodeExportPath => Path.Combine(AppContext.BaseDirectory, "GeneratedCode");
+    
+    /// <summary>
+    /// Try get the export path for code generation, if not found, use fallback path
+    /// </summary>
+    /// <param name="usage">The usage type to get export path for</param>
+    /// <returns>Export path for the usage, or fallback path if not configured</returns>
+    public string GetCodeExportPath(string usage)
+    {
+        if (ExportPath.TryGetValue(usage, out var exportPath))
+        {
+            return exportPath;
+        }
+        
+        return FallbackCodeExportPath;
+    }
+}

--- a/TableCraft.Editor/Models/AppSettings.cs
+++ b/TableCraft.Editor/Models/AppSettings.cs
@@ -10,25 +10,25 @@ namespace TableCraft.Editor.Models;
 public class AppSettings
 {
     /// <summary>
+    /// Fallback export path when specific usage is not configured
+    /// </summary>
+    public static string FallbackCodeExportPath => Path.Combine(AppContext.BaseDirectory, "GeneratedCode");
+
+    /// <summary>
     /// Common root directory of configuration files for reading configuration files
     /// </summary>
     public string ConfigHomePath { get; set; } = string.Empty;
-    
+
     /// <summary>
     /// Common root directory of configuration description files for saving description files
     /// </summary>
     public string JsonHomePath { get; set; } = string.Empty;
-    
+
     /// <summary>
     /// Export directories for different usage types
     /// </summary>
     public Dictionary<string, string> ExportPath { get; set; } = new();
-    
-    /// <summary>
-    /// Fallback export path when specific usage is not configured
-    /// </summary>
-    public static string FallbackCodeExportPath => Path.Combine(AppContext.BaseDirectory, "GeneratedCode");
-    
+
     /// <summary>
     /// Try get the export path for code generation, if not found, use fallback path
     /// </summary>
@@ -40,7 +40,7 @@ public class AppSettings
         {
             return exportPath;
         }
-        
+
         return FallbackCodeExportPath;
     }
 }

--- a/TableCraft.Editor/Models/ConfigFileElement.cs
+++ b/TableCraft.Editor/Models/ConfigFileElement.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.Extensions.DependencyInjection;
 using Path = System.IO.Path;
 
 namespace TableCraft.Editor.Models;
@@ -20,7 +21,8 @@ public class ConfigFileElement : IComparable<ConfigFileElement>
 
     public string GetConfigFileFullPath()
     {
-        return Path.Combine(Program.GetConfigHomePath(), ConfigFileRelativePath);
+        var appSettings = Program.Host.Services.GetRequiredService<AppSettings>();
+        return Path.Combine(appSettings.ConfigHomePath, ConfigFileRelativePath);
     }
 
     public string GetJsonFileFullPath()
@@ -30,7 +32,8 @@ public class ConfigFileElement : IComparable<ConfigFileElement>
             return string.Empty;
         }
 
-        return Path.Combine(Program.GetJsonHomePath(), JsonFileRelativePath);
+        var appSettings = Program.Host.Services.GetRequiredService<AppSettings>();
+        return Path.Combine(appSettings.JsonHomePath, JsonFileRelativePath);
     }
 
     public int CompareTo(ConfigFileElement? other)

--- a/TableCraft.Editor/Program.cs
+++ b/TableCraft.Editor/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Serilog;
+using TableCraft.Editor.Models;
 using TableCraft.Editor.Services;
 
 namespace TableCraft.Editor;
@@ -16,9 +17,6 @@ class Program
     public const string ListJsonFilename = "list.json";
     public const string LibEnvJsonFilename = "libenv.json";
     public static IHost Host { get; private set; } = null!;
-
-    private static readonly string m_FallbackCodeExportPath = Path.Combine(AppContext.BaseDirectory, "GeneratedCode");
-    private static IConfiguration? m_Configuration;
 
     // Initialization code. Don't use any Avalonia, third-party APIs or any
     // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
@@ -42,15 +40,28 @@ class Program
                 .ConfigureServices(services =>
                 {
                     services.AddSingleton<IP4ConfigManager, P4ConfigManager>();
+                    services.AddSingleton<AppSettings>(provider =>
+                    {
+                        var configuration = provider.GetRequiredService<IConfiguration>();
+                        var appSettings = configuration.Get<AppSettings>();
+                        if (appSettings == null)
+                        {
+                            throw new InvalidOperationException("Failed to load application settings from appsettings.json");
+                        }
+                        return appSettings;
+                    });
                 })
                 .Build();
 
-            m_Configuration = Host.Services.GetRequiredService<IConfiguration>();
+            // Trigger AppSettings registration to validate configuration early
+            Host.Services.GetRequiredService<AppSettings>();
             Log.Information("Configuration is ready");
             
-            var libEnvJsonFilePath = AppContext.BaseDirectory + LibEnvJsonFilename;
+            var libEnvJsonFilePath = Path.Combine(AppContext.BaseDirectory, LibEnvJsonFilename);
             if (!File.Exists(libEnvJsonFilePath))
+            {
                 throw new FileNotFoundException("library configuration file not found", LibEnvJsonFilename);
+            }
             
             // we initialize library here and build Avalonia app anyway,
             // later we check if it's initialized in App.OnFrameworkInitializationCompleted
@@ -80,50 +91,6 @@ class Program
             .UsePlatformDetect()
             .LogToTrace(LogEventLevel.Debug, LogArea.Control)
             .UseReactiveUI();
-
-    #region Application Setting
-
-    // TODO to singleton later?
-
-    public static string GetConfigHomePath()
-    {
-        if (m_Configuration == null)
-        {
-            throw new Exception("m_Configuration from appsettings is null");
-        }
-
-        var path = m_Configuration.GetValue<string>("ConfigHomePath");
-        return path ?? string.Empty;
-    }
-
-    public static string GetJsonHomePath()
-    {
-        if (m_Configuration == null)
-        {
-            throw new Exception("m_Configuration from appsettings is null");
-        }
-
-        var path = m_Configuration.GetValue<string>("JsonHomePath");
-        return path ?? string.Empty;
-    }
-
-    /// <summary>
-    /// Try get the export path for code generation from appsettings.json, if not found, use <see cref="m_FallbackCodeExportPath"/>
-    /// </summary>
-    /// <param name="usage"></param>
-    /// <returns></returns>
-    /// <exception cref="NullReferenceException"></exception>
-    public static string GetCodeExportPath(string usage)
-    {
-        if (m_Configuration == null) throw new NullReferenceException("m_Configuration from appsettings is null");
-
-        var section = m_Configuration.GetSection("ExportPath");
-        // section is not null, if 'ExportPath' not found, empty section will return a null string
-        var exportPath = section.GetValue<string>(usage);
-        return exportPath ?? m_FallbackCodeExportPath;
-    }
-
-    #endregion
 
     #region Logger
 

--- a/TableCraft.Editor/Program.cs
+++ b/TableCraft.Editor/Program.cs
@@ -2,17 +2,11 @@
 using Avalonia.ReactiveUI;
 using System;
 using System.IO;
-using System.Linq;
-using System.Text.Json;
-using System.Text.Json.Nodes;
-using System.Threading.Tasks;
 using Avalonia.Logging;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Serilog;
-using TableCraft.Core.IO;
-using TableCraft.Core.VersionControl;
 using TableCraft.Editor.Services;
 
 namespace TableCraft.Editor;
@@ -21,10 +15,9 @@ class Program
 {
     public const string ListJsonFilename = "list.json";
     public const string LibEnvJsonFilename = "libenv.json";
-    public const string AppSettingsFilename = "appsettings.json";
+    public static IHost Host { get; private set; } = null!;
 
     private static readonly string m_FallbackCodeExportPath = Path.Combine(AppContext.BaseDirectory, "GeneratedCode");
-    private static IHost? m_Host;
     private static IConfiguration? m_Configuration;
 
     // Initialization code. Don't use any Avalonia, third-party APIs or any
@@ -40,14 +33,20 @@ class Program
             .WriteTo.File("Logs/log-.txt", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 10)
             .CreateLogger();
 
-        Log.Information("Logger is initialized");
+        Log.Information("Logger is ready");
 
         try
         {
             // Move host and configuration initialization into try-catch after logger is ready
-            m_Host = Host.CreateDefaultBuilder(args).Build();
-            m_Configuration = m_Host.Services.GetRequiredService<IConfiguration>();
-            Log.Information("Configuration loaded successfully");
+            Host = Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder(args)
+                .ConfigureServices(services =>
+                {
+                    services.AddSingleton<IP4ConfigManager, P4ConfigManager>();
+                })
+                .Build();
+
+            m_Configuration = Host.Services.GetRequiredService<IConfiguration>();
+            Log.Information("Configuration is ready");
             
             var libEnvJsonFilePath = AppContext.BaseDirectory + LibEnvJsonFilename;
             if (!File.Exists(libEnvJsonFilePath))
@@ -58,9 +57,10 @@ class Program
             Core.Debugger.InitialCustomLogger(Log.Information, Core.Debugger.LogLevel.Information);
             Core.Debugger.InitialCustomLogger(Log.Warning, Core.Debugger.LogLevel.Warning);
             Core.Debugger.InitialCustomLogger(Log.Error, Core.Debugger.LogLevel.Error);
-            Log.Information("try initializing library with '{LibEnvJson}'", libEnvJsonFilePath);
+            Log.Information("try setup TableCraft.Core with: {LibEnvJson}", libEnvJsonFilePath);
             Core.Configuration.ReadConfigurationFromJson(libEnvJsonFilePath);
-            
+            Log.Information("TableCraft.Core is ready");
+
             BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
         }
         catch (Exception e)
@@ -121,114 +121,6 @@ class Program
         // section is not null, if 'ExportPath' not found, empty section will return a null string
         var exportPath = section.GetValue<string>(usage);
         return exportPath ?? m_FallbackCodeExportPath;
-    }
-    
-    public static PerforceUserConfig GetVersionControlConfig()
-    {
-        if (m_Configuration == null) throw new NullReferenceException("m_Configuration from appsettings is null");
-
-        var emptyConfig = new PerforceUserConfig();
-        var section = m_Configuration.GetSection("P4Config");
-        if (!section.Exists())
-        {
-            return emptyConfig;
-        }
-
-        var children = section.GetChildren();
-        if (children.Any(child => string.IsNullOrEmpty(child.Value)))
-        {
-            return emptyConfig;
-        }
-
-        var config = section.Get<PerforceUserConfig>();
-        if (config == null || config.P4PORT == null)
-        {
-            Log.Error("[Program.GetVersionControlConfig] get PerforceUserConfig from appsettings failed!");
-            return emptyConfig;
-        }
-        
-        config.Decode();
-        return config;
-    }
-    
-    /// <summary>
-    /// <para> This is (still) a bad approach to update perforce configuration in appsettings.json:
-    /// we deserialize the whole appsettings json file, update / add related content, then serialize and write it back </para>
-    /// </summary>
-    /// <param name="config"></param>
-    /// <returns></returns>
-    public static async Task<bool> UpdateVersionControlConfig(PerforceUserConfig config)
-    {
-        config.Encode(); // make sure we have encoded password
-        var appSettingsFilePath = Path.Combine(AppContext.BaseDirectory, AppSettingsFilename);
-        if (!File.Exists(appSettingsFilePath))
-        {
-            Log.Error("[UpdateVersionControlConfig] AppSettings file not found: {FilePath}", appSettingsFilePath);
-            return false;
-        }
-
-        var appSettingsContent = await FileHelper.ReadToEnd(appSettingsFilePath);
-        if (string.IsNullOrEmpty(appSettingsContent))
-        {
-            Log.Error("[UpdateVersionControlConfig] AppSettings file is empty or could not be read: {FilePath}", appSettingsFilePath);
-            return false;
-        }
-
-        var appSettingsJsonData = JsonNode.Parse(appSettingsContent);
-        if (appSettingsJsonData == null)
-        {
-            Log.Error("[UpdateVersionControlConfig] Failed to parse appsettings.json as valid JSON");
-            return false;
-        }
-        
-        var p4ConfigJsonStr = JsonSerializer.Serialize(config);
-        var p4ConfigJsonNode = JsonNode.Parse(p4ConfigJsonStr);
-        if (p4ConfigJsonNode == null)
-        {
-            Log.Error("[UpdateVersionControlConfig] Failed to serialize PerforceUserConfig to JSON");
-            return false;
-        }
-        
-        // remove sensitive information
-        if (p4ConfigJsonNode is JsonObject p4ConfigObject)
-        {
-            p4ConfigObject.Remove(nameof(config.P4Passwd));
-        }
-        
-        if (appSettingsJsonData is JsonObject appSettingsObject)
-        {
-            appSettingsObject["P4Config"] = p4ConfigJsonNode;
-        }
-        else
-        {
-            Log.Error("[UpdateVersionControlConfig] AppSettings root is not a JSON object, cannot update P4Config");
-            return false;
-        }
-
-        try
-        {
-            var jsonOptions = new JsonSerializerOptions
-            {
-                WriteIndented = true
-            };
-
-            var updatedJson = JsonSerializer.Serialize(appSettingsJsonData, jsonOptions);
-            await FileHelper.WriteAsync(appSettingsFilePath, updatedJson);
-        }
-        catch (UnauthorizedAccessException exception)
-        {
-            Log.Error(exception, "[UpdateVersionControlConfig] UnauthorizedAccessException when writing to appsettings.json: {FilePath}", appSettingsFilePath);
-            await MessageBoxManager.ShowStandardMessageBoxDialog("UnauthorizedAccessException",
-                $"Failed to write '{appSettingsFilePath}', checkout the file yourself if you're using Perforce \n\nstack trace:\n{exception}");
-            return false;
-        }
-        catch (Exception exception)
-        {
-            Log.Error(exception, "[UpdateVersionControlConfig] Unexpected exception when writing to appsettings.json: {FilePath}", appSettingsFilePath);
-            return false;
-        }
-        
-        return true;
     }
 
     #endregion

--- a/TableCraft.Editor/Services/ConfigFileRegistry.cs
+++ b/TableCraft.Editor/Services/ConfigFileRegistry.cs
@@ -10,11 +10,11 @@ using TableCraft.Editor.Models;
 
 namespace TableCraft.Editor.Services;
 
-public class FakeDatabase
+public class ConfigFileRegistry
 {
     private readonly string m_ListJsonFilePath;
 
-    public FakeDatabase(string listJsonFilePath)
+    public ConfigFileRegistry(string listJsonFilePath)
     {
         m_ListJsonFilePath = listJsonFilePath;
     }
@@ -70,6 +70,6 @@ public class FakeDatabase
         });
         
         await FileHelper.WriteAsync(m_ListJsonFilePath, jsonString);
-        Log.Information("write ListJsonFile '{Path}' finished", m_ListJsonFilePath);
+        Log.Information("write list.json file '{Path}' finished", m_ListJsonFilePath);
     }
 }

--- a/TableCraft.Editor/Services/IP4ConfigManager.cs
+++ b/TableCraft.Editor/Services/IP4ConfigManager.cs
@@ -1,0 +1,35 @@
+using System.Threading.Tasks;
+using TableCraft.Core.VersionControl;
+
+namespace TableCraft.Editor.Services;
+
+/// <summary>
+/// Interface for managing Perforce configuration stored in user directory
+/// </summary>
+public interface IP4ConfigManager
+{
+    /// <summary>
+    /// Gets the full path to the P4 configuration file
+    /// </summary>
+    /// <returns>Full path to p4config.json</returns>
+    string GetConfigFilePath();
+
+    /// <summary>
+    /// Checks if P4 configuration exists
+    /// </summary>
+    /// <returns>True if p4config.json exists</returns>
+    bool ConfigExists();
+
+    /// <summary>
+    /// Gets the Perforce configuration from user directory
+    /// </summary>
+    /// <returns>PerforceUserConfig object, empty if not found or invalid</returns>
+    PerforceUserConfig GetVersionControlConfig();
+
+    /// <summary>
+    /// Saves the Perforce configuration to user directory
+    /// </summary>
+    /// <param name="config">The PerforceUserConfig to save</param>
+    /// <returns>True if successful, false otherwise</returns>
+    Task<bool> UpdateVersionControlConfig(PerforceUserConfig config);
+}

--- a/TableCraft.Editor/Services/P4ConfigManager.cs
+++ b/TableCraft.Editor/Services/P4ConfigManager.cs
@@ -105,7 +105,7 @@ public class P4ConfigManager : IP4ConfigManager
             var configJson = JsonSerializer.Serialize(config, options);
             await FileHelper.WriteAsync(m_P4ConfigFilePath, configJson);
 
-            Log.Information(" Successfully saved P4 config to: {FilePath}", m_P4ConfigFilePath);
+            Log.Information("Successfully saved P4 config to: {FilePath}", m_P4ConfigFilePath);
             return true;
         }
         catch (Exception ex)

--- a/TableCraft.Editor/Services/P4ConfigManager.cs
+++ b/TableCraft.Editor/Services/P4ConfigManager.cs
@@ -1,0 +1,117 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Serilog;
+using TableCraft.Core.IO;
+using TableCraft.Core.VersionControl;
+
+namespace TableCraft.Editor.Services;
+
+/// <summary>
+/// Manages Perforce configuration stored in user directory instead of appsettings.json
+/// </summary>
+public class P4ConfigManager : IP4ConfigManager
+{
+    private static readonly string m_ConfigDirectory = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        m_ConfigDirectoryName);
+
+    private static readonly string m_P4ConfigFilePath = Path.Combine(m_ConfigDirectory, m_P4ConfigFileName);
+
+    private const string m_ConfigDirectoryName = "TableCraft";
+    private const string m_P4ConfigFileName = "p4config.json";
+
+    /// <summary>
+    /// Gets the full path to the P4 configuration file
+    /// </summary>
+    /// <returns>Full path to p4config.json</returns>
+    public string GetConfigFilePath()
+    {
+        return m_P4ConfigFilePath;
+    }
+
+    /// <summary>
+    /// Checks if P4 configuration exists
+    /// </summary>
+    /// <returns>True if p4config.json exists</returns>
+    public bool ConfigExists()
+    {
+        return File.Exists(m_P4ConfigFilePath);
+    }
+
+    /// <summary>
+    /// Gets the Perforce configuration from user directory
+    /// </summary>
+    /// <returns>PerforceUserConfig object, empty if not found or invalid</returns>
+    public PerforceUserConfig GetVersionControlConfig()
+    {
+        var emptyConfig = new PerforceUserConfig();
+
+        if (!File.Exists(m_P4ConfigFilePath))
+        {
+            Log.Information("P4 config file not found: {FilePath}", m_P4ConfigFilePath);
+            return emptyConfig;
+        }
+
+        try
+        {
+            var configContent = FileHelper.ReadAllText(m_P4ConfigFilePath);
+            if (string.IsNullOrEmpty(configContent))
+            {
+                Log.Warning("P4 config file is empty: {FilePath}", m_P4ConfigFilePath);
+                return emptyConfig;
+            }
+
+            var config = JsonSerializer.Deserialize<PerforceUserConfig>(configContent);
+            if (config == null || string.IsNullOrEmpty(config.P4PORT))
+            {
+                Log.Warning("Invalid P4 configuration in file: {FilePath}", m_P4ConfigFilePath);
+                return emptyConfig;
+            }
+
+            config.Decode();
+            
+            Log.Information("Successfully loaded P4 config from: {FilePath}", m_P4ConfigFilePath);
+            return config;
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Unexpected error reading P4 config: {FilePath}",
+                m_P4ConfigFilePath);
+            return emptyConfig;
+        }
+    }
+
+    /// <summary>
+    /// Saves the Perforce configuration to user directory
+    /// </summary>
+    /// <param name="config">The PerforceUserConfig to save</param>
+    /// <returns>True if successful, false otherwise</returns>
+    public async Task<bool> UpdateVersionControlConfig(PerforceUserConfig config)
+    {
+        config.Encode(); // ensure password is encoded
+
+        try
+        {
+            // ensure directory exists
+            Directory.CreateDirectory(m_ConfigDirectory);
+
+            var options = new JsonSerializerOptions
+            {
+                WriteIndented = true
+            };
+
+            var configJson = JsonSerializer.Serialize(config, options);
+            await FileHelper.WriteAsync(m_P4ConfigFilePath, configJson);
+
+            Log.Information(" Successfully saved P4 config to: {FilePath}", m_P4ConfigFilePath);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, " Unexpected error saving P4 config: {FilePath}", m_P4ConfigFilePath);
+            return false;
+        }
+    }
+}

--- a/TableCraft.Editor/Services/P4ConfigManager.cs
+++ b/TableCraft.Editor/Services/P4ConfigManager.cs
@@ -110,7 +110,7 @@ public class P4ConfigManager : IP4ConfigManager
         }
         catch (Exception ex)
         {
-            Log.Error(ex, " Unexpected error saving P4 config: {FilePath}", m_P4ConfigFilePath);
+            Log.Error(ex, "Unexpected error saving P4 config: {FilePath}", m_P4ConfigFilePath);
             return false;
         }
     }

--- a/TableCraft.Editor/TableCraft.Editor.csproj
+++ b/TableCraft.Editor/TableCraft.Editor.csproj
@@ -6,9 +6,9 @@
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Assets\CraftingTable_256.ico</ApplicationIcon>
-    <Version>1.4.3</Version>
-    <AssemblyVersion>1.4.3</AssemblyVersion>
-    <FileVersion>1.4.3</FileVersion>
+    <Version>1.4.4</Version>
+    <AssemblyVersion>1.4.4</AssemblyVersion>
+    <FileVersion>1.4.4</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TableCraft.Editor/ViewModels/MainWindowViewModel.cs
+++ b/TableCraft.Editor/ViewModels/MainWindowViewModel.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Platform.Storage;
 using FuzzySharp;
+using Microsoft.Extensions.DependencyInjection;
 using TableCraft.Core;
 using TableCraft.Editor.Models;
 using TableCraft.Editor.Services;
@@ -451,7 +452,7 @@ public class MainWindowViewModel : ViewModelBase
 
     private async Task OnOpenPerforceWindowButtonClicked()
     {
-        var config = Program.GetVersionControlConfig();
+        var config = Program.Host.Services.GetRequiredService<IP4ConfigManager>().GetVersionControlConfig();
         var viewModel = new PerforceUserConfigViewModel(config);
         await ShowPerforceWindow.Handle(viewModel);
 

--- a/TableCraft.Editor/ViewModels/MainWindowViewModel.cs
+++ b/TableCraft.Editor/ViewModels/MainWindowViewModel.cs
@@ -48,9 +48,9 @@ public class MainWindowViewModel : ViewModelBase
 
     public string ListJsonFilename => Program.ListJsonFilename;
 
-    public string ConfigHomePath => Program.GetConfigHomePath();
+    public string ConfigHomePath => Program.Host.Services.GetRequiredService<AppSettings>().ConfigHomePath;
 
-    public string JsonHomePath => Program.GetJsonHomePath();
+    public string JsonHomePath => Program.Host.Services.GetRequiredService<AppSettings>().JsonHomePath;
 
     private string m_ExportCodeUsage = string.Empty;
 
@@ -294,7 +294,8 @@ public class MainWindowViewModel : ViewModelBase
         if (configInfo == null)
         {
             Log.Error("Failed to create config info for '{identifier}' under '{HomePath}'",
-                selectedTable.ConfigFileRelativePath, Program.GetConfigHomePath());
+                selectedTable.ConfigFileRelativePath,
+                Program.Host.Services.GetRequiredService<AppSettings>().ConfigHomePath);
             SelectedConfigInfo = null;
             return;
         }
@@ -436,7 +437,8 @@ public class MainWindowViewModel : ViewModelBase
         var isUsageGroup = Configuration.IsDefinedUsageGroup(m_ExportCodeUsage);
         if (!isUsageGroup) // single usage
         {
-            var codeExportHomePath = Program.GetCodeExportPath(m_ExportCodeUsage);
+            var appSettings = Program.Host.Services.GetRequiredService<Models.AppSettings>();
+            var codeExportHomePath = appSettings.GetCodeExportPath(m_ExportCodeUsage);
             ExportCodePath = SelectedConfigInfo != null
                 ? Path.Combine(codeExportHomePath, Configuration.GetTargetFilenameForUsage(m_ExportCodeUsage, SelectedConfigInfo.GetConfigInfo()))
                 : codeExportHomePath;
@@ -507,18 +509,20 @@ public class MainWindowViewModel : ViewModelBase
         var isUsageGroup = Configuration.IsDefinedUsageGroup(m_ExportCodeUsage);
         if (!isUsageGroup)
         {
-            var outputDir = Program.GetCodeExportPath(m_ExportCodeUsage);
+            var appSettings = Program.Host.Services.GetRequiredService<Models.AppSettings>();
+            var outputDir = appSettings.GetCodeExportPath(m_ExportCodeUsage);
             // if 'ConfigInfo' is null, GenerateCodeForUsage will handle it and return false
             success =
                 await ConfigManager.singleton.GenerateCodeForUsage(m_ExportCodeUsage, configInfo, outputDir);
         }
         else
         {
+            var appSettings = Program.Host.Services.GetRequiredService<Models.AppSettings>();
             var usages = Configuration.GetUsagesForGroup(m_ExportCodeUsage);
             var outputDirectories = new string[usages.Length];
             for (var i = 0; i < usages.Length; i++)
             {
-                outputDirectories[i] = Program.GetCodeExportPath(usages[i]);
+                outputDirectories[i] = appSettings.GetCodeExportPath(usages[i]);
             }
             
             // generate multiple code files for each usage

--- a/TableCraft.Editor/ViewModels/PerforceUserConfigViewModel.cs
+++ b/TableCraft.Editor/ViewModels/PerforceUserConfigViewModel.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Reactive;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using ReactiveUI;
 using TableCraft.Core.VersionControl;
 using TableCraft.Editor.Services;
@@ -113,7 +114,7 @@ public class PerforceUserConfigViewModel : ViewModelBase
 
     private async Task OnSaveButtonClicked()
     {
-        var result = await Program.UpdateVersionControlConfig(m_PerforceUserConfig);
+        var result = await Program.Host.Services.GetRequiredService<IP4ConfigManager>().UpdateVersionControlConfig(m_PerforceUserConfig);
         var popupTitle = result ? MessageBoxManager.SuccessTitle : MessageBoxManager.ErrorTitle;
         var popupContent = result ? "Perforce configuration saved!" : "Failed to save Perforce configuration";
         await MessageBoxManager.ShowStandardMessageBoxDialog(popupTitle, popupContent);

--- a/TableCraft.Editor/Views/PerforceUserConfigWindow.axaml
+++ b/TableCraft.Editor/Views/PerforceUserConfigWindow.axaml
@@ -9,7 +9,7 @@
         Width="480" Height="270"
         CanResize="False"
         WindowStartupLocation="CenterOwner"
-        Icon="/Assets/avalonia-logo.ico"
+        Icon="/Assets/CraftingTable_256.ico"
         Title="Perforce">
     
     <Window.Resources>


### PR DESCRIPTION
This pull request refactors configuration management in TableCraft.Editor, improves documentation, and introduces a new strongly typed settings model. The changes remove Perforce version control settings from `appsettings.json` and relocate them to a user-specific configuration file, simplify code by replacing the legacy configuration access pattern with dependency injection, and update documentation to reflect these improvements.

**Configuration Refactoring and Code Simplification:**

* Introduced a strongly typed `AppSettings` model for application settings, replacing direct configuration access and legacy static methods. Configuration is now provided via dependency injection throughout the codebase (`TableCraft.Editor/Models/AppSettings.cs`, `TableCraft.Editor/Program.cs`). [[1]](diffhunk://#diff-0994099bf4a7a175341a84d20f4fdeaaace1495c0274a6864e430a114afe4c5dR1-R46) [[2]](diffhunk://#diff-d926522991e76b452bbfbe8d836d46f74fc1e9f746c8b011fdc933b7a36a3a39L5-R10) [[3]](diffhunk://#diff-d926522991e76b452bbfbe8d836d46f74fc1e9f746c8b011fdc933b7a36a3a39L24-R19)
* Refactored configuration file path resolution in `ConfigFileElement` to use the injected `AppSettings` instead of static methods (`TableCraft.Editor/Models/ConfigFileElement.cs`). [[1]](diffhunk://#diff-e070ebecb4e2d79f786ff927c9ae5b6510e7a7d53c06a5edf6b63727a7bf1cedR2) [[2]](diffhunk://#diff-e070ebecb4e2d79f786ff927c9ae5b6510e7a7d53c06a5edf6b63727a7bf1cedL23-R25) [[3]](diffhunk://#diff-e070ebecb4e2d79f786ff927c9ae5b6510e7a7d53c06a5edf6b63727a7bf1cedL33-R36)
* Renamed `FakeDatabase` to `ConfigFileRegistry` for clarity and updated related usages (`TableCraft.Editor/Services/ConfigFileRegistry.cs`, `TableCraft.Editor/App.axaml.cs`). [[1]](diffhunk://#diff-f4b41beca2de82acf4c7811b8f602adfaf0ea02dd006b632452aa5ed6a22bad7L13-R17) [[2]](diffhunk://#diff-6211c94058b54555b86371383c1b171292e256309395230b160d3b3515af804dL37-R45) [[3]](diffhunk://#diff-f4b41beca2de82acf4c7811b8f602adfaf0ea02dd006b632452aa5ed6a22bad7L73-R73)

**Perforce Version Control Configuration Changes:**

* Removed Perforce configuration from `appsettings.json`; it is now stored in a user directory (`p4config.json`) and managed via the application's settings interface. Updated code to retrieve Perforce configuration through the new manager service (`TableCraft.Core/VersionControl/PerforceUserConfig.cs`, `TableCraft.Editor/App.axaml.cs`). [[1]](diffhunk://#diff-3b2d08ee5d881c871e6943ba6da757c1899a5263de585ae60694e7dbe1075218R20) [[2]](diffhunk://#diff-6211c94058b54555b86371383c1b171292e256309395230b160d3b3515af804dL54-R55)

**Documentation Updates:**

* Updated both English and Chinese README files to reflect the new Perforce configuration location and usage, and added status badges for license, build, and release information (`README.en.md`, `README.md`). [[1]](diffhunk://#diff-b4f47ddd2e9baf4f63a8b1c7adb79cc6caabfe2958e82d73d7b80d1468075213R3-R6) [[2]](diffhunk://#diff-b4f47ddd2e9baf4f63a8b1c7adb79cc6caabfe2958e82d73d7b80d1468075213L163-R167) [[3]](diffhunk://#diff-b4f47ddd2e9baf4f63a8b1c7adb79cc6caabfe2958e82d73d7b80d1468075213L174-R189) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R3-R6) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L165-R169) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L176-R191)