### PR TITLE
Feat/auto update

### DIFF
--- a/Example/appsettings.json
+++ b/Example/appsettings.json
@@ -1,4 +1,5 @@
 ﻿{
+    "CheckForUpdates": true,
     "ConfigHomePath": "[your-config-home-path]",
     "JsonHomePath": "[your-json-home-path]",
     "ExportPath": {

--- a/TableCraft.Editor/App.axaml.cs
+++ b/TableCraft.Editor/App.axaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
@@ -70,6 +71,13 @@ public partial class App : Application
 
     private static async void CheckForUpdatesOnStartup()
     {
+        // Auto-update is only supported on Windows (downloads .exe installer)
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Log.Information("[App.CheckForUpdatesOnStartup] Auto-update is only supported on Windows, skipping");
+            return;
+        }
+
         try
         {
             var autoUpdateService = Program.Host.Services.GetRequiredService<IAutoUpdateService>();

--- a/TableCraft.Editor/App.axaml.cs
+++ b/TableCraft.Editor/App.axaml.cs
@@ -9,6 +9,7 @@ using TableCraft.Editor.Services;
 using TableCraft.Editor.ViewModels;
 using TableCraft.Editor.Views;
 using Serilog;
+using TableCraft.Editor.Models;
 
 namespace TableCraft.Editor;
 
@@ -48,7 +49,10 @@ public partial class App : Application
 
         base.OnFrameworkInitializationCompleted();
         Task.Run(LoadAndRegisterVersionControl);
-        Task.Run(CheckForUpdatesOnStartup);
+        if (Program.Host.Services.GetRequiredService<AppSettings>().CheckForUpdates)
+        {
+            Task.Run(CheckForUpdatesOnStartup);
+        }
     }
 
     private static void LoadAndRegisterVersionControl()

--- a/TableCraft.Editor/App.axaml.cs
+++ b/TableCraft.Editor/App.axaml.cs
@@ -48,6 +48,7 @@ public partial class App : Application
 
         base.OnFrameworkInitializationCompleted();
         Task.Run(LoadAndRegisterVersionControl);
+        Task.Run(CheckForUpdatesOnStartup);
     }
 
     private static void LoadAndRegisterVersionControl()
@@ -61,5 +62,18 @@ public partial class App : Application
 
         var versionControl = new Core.VersionControl.Perforce(versionControlConfig);
         Core.IO.FileHelper.RegisterFileEvent(versionControl);
+    }
+
+    private static async void CheckForUpdatesOnStartup()
+    {
+        try
+        {
+            var autoUpdateService = Program.Host.Services.GetRequiredService<IAutoUpdateService>();
+            await autoUpdateService.CheckLocalDownloadedUpdatesAsync();
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "[App.CheckForUpdatesOnStartup] Failed to check for updates");
+        }
     }
 }

--- a/TableCraft.Editor/Models/AppSettings.cs
+++ b/TableCraft.Editor/Models/AppSettings.cs
@@ -15,6 +15,11 @@ public class AppSettings
     public static string FallbackCodeExportPath => Path.Combine(AppContext.BaseDirectory, "GeneratedCode");
 
     /// <summary>
+    /// If true, the application will check for updates on startup
+    /// </summary>
+    public bool CheckForUpdates { get; set; } = true;
+
+    /// <summary>
     /// Common root directory of configuration files for reading configuration files
     /// </summary>
     public string ConfigHomePath { get; set; } = string.Empty;

--- a/TableCraft.Editor/Models/ReleaseInfo.cs
+++ b/TableCraft.Editor/Models/ReleaseInfo.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+
+namespace TableCraft.Editor.Models;
+
+public class ReleaseInfo
+{
+    public string TagName { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string Body { get; set; } = string.Empty;
+    public bool IsPrerelease { get; set; }
+    public DateTime PublishedAt { get; set; }
+    public List<ReleaseAsset> Assets { get; set; } = new();
+}
+
+public class ReleaseAsset
+{
+    public string Name { get; set; } = string.Empty;
+    public string DownloadUrl { get; set; } = string.Empty;
+    public long Size { get; set; }
+    public string ContentType { get; set; } = string.Empty;
+}

--- a/TableCraft.Editor/Services/AutoUpdateService.cs
+++ b/TableCraft.Editor/Services/AutoUpdateService.cs
@@ -1,0 +1,185 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Serilog;
+
+namespace TableCraft.Editor.Services;
+
+public class AutoUpdateService : IAutoUpdateService
+{
+    private const string GitHubOwner = "kalulas";
+    private const string GitHubRepository = "TableCraft";
+
+    private readonly IReleaseService m_ReleaseService;
+    private readonly IVersionService m_VersionService;
+    private readonly IDownloadService m_DownloadService;
+    private readonly IFileManagementService m_FileManagementService;
+    private readonly IInstallerService m_InstallerService;
+    private readonly ILogger m_Logger;
+
+    public AutoUpdateService(
+        IReleaseService releaseService,
+        IVersionService versionService,
+        IDownloadService downloadService,
+        IFileManagementService fileManagementService,
+        IInstallerService installerService)
+    {
+        m_ReleaseService = releaseService;
+        m_VersionService = versionService;
+        m_DownloadService = downloadService;
+        m_FileManagementService = fileManagementService;
+        m_InstallerService = installerService;
+        m_Logger = Log.ForContext<AutoUpdateService>();
+    }
+
+    public async Task CheckLocalDownloadedUpdatesAsync()
+    {
+        try
+        {
+            m_Logger.Information("Checking for locally downloaded updates");
+            
+            var latestSetupFile = m_FileManagementService.FindLatestLocalSetup();
+            if (string.IsNullOrEmpty(latestSetupFile))
+            {
+                m_Logger.Information("No local setup files found, checking for new releases");
+                await CheckForNewReleaseAsync();
+                return;
+            }
+
+            var fileName = Path.GetFileName(latestSetupFile);
+            var confirmInstall = await MessageBoxManager.ShowConfirmationDialog(
+                "Found Local Update", 
+                $"A previously downloaded update was found: '{fileName}'.\nWould you like to install it now?");
+
+            if (confirmInstall)
+            {
+                m_Logger.Information("User confirmed installation of local update: {SetupFile}", latestSetupFile);
+                await m_InstallerService.ExecuteInstallerAsync(latestSetupFile);
+            }
+            else
+            {
+                m_Logger.Information("User declined installation of local update");
+            }
+        }
+        catch (Exception ex)
+        {
+            m_Logger.Error(ex, "Failed to check local downloaded updates");
+        }
+    }
+
+    public async Task<bool> CheckForNewReleaseAsync()
+    {
+        try
+        {
+            m_Logger.Information("Checking for new releases from GitHub repository '{Owner}/{Repository}'", 
+                GitHubOwner, GitHubRepository);
+            
+            var latestRelease = await m_ReleaseService.GetLatestReleaseAsync(GitHubOwner, GitHubRepository);
+            if (latestRelease == null)
+            {
+                m_Logger.Warning("Failed to get latest release information");
+                return false;
+            }
+
+            var currentVersion = m_VersionService.GetCurrentVersion();
+            var latestVersion = m_VersionService.ParseVersion(latestRelease.TagName);
+
+            if (latestVersion == null)
+            {
+                m_Logger.Warning("Failed to parse latest version: {TagName}", latestRelease.TagName);
+                return false;
+            }
+
+            if (!m_VersionService.IsNewerVersion(currentVersion, latestVersion))
+            {
+                m_Logger.Information("Current version '{CurrentVersion}' is up to date with latest '{LatestVersion}'", 
+                    currentVersion, latestVersion);
+                return false;
+            }
+
+            m_Logger.Information("New version available '{LatestVersion}' (current '{CurrentVersion}')", 
+                latestVersion, currentVersion);
+            
+            // var confirmDownload = await MessageBoxManager.ShowConfirmationDialog(
+            const string newLine = "\r\n\r\n";
+            var confirmDownload = await MessageBoxManager.ShowCustomMarkdownMessageBoxConfirmationDialog(
+                "New Version Released", 
+                $"New version [{latestRelease.TagName}] has been detected.{newLine}" +
+                $"Would you like to download it now?{newLine}" +
+                $"**Release Notes**{newLine}" +
+                $"{latestRelease.Body}");
+
+            if (confirmDownload)
+            {
+                return await DownloadAndInstallUpdateAsync();
+            }
+
+            m_Logger.Information("New version available '{LatestVersion}' but user declined download", latestVersion);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            m_Logger.Error(ex, "Failed to check for new releases");
+            return false;
+        }
+    }
+
+    public async Task<bool> DownloadAndInstallUpdateAsync()
+    {
+        try
+        {
+            var latestRelease = await m_ReleaseService.GetLatestReleaseAsync(GitHubOwner, GitHubRepository);
+            if (latestRelease == null)
+            {
+                return false;
+            }
+
+            var setupAsset = latestRelease.Assets.FirstOrDefault(a => 
+                a.Name.Contains("setup", StringComparison.OrdinalIgnoreCase) && 
+                a.Name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase));
+
+            if (setupAsset == null)
+            {
+                m_Logger.Warning("No setup.exe file found in release assets");
+                return false;
+            }
+
+            var updateDirectory = m_FileManagementService.GetUpdateDirectory();
+            var destinationPath = Path.Combine(updateDirectory, setupAsset.Name);
+
+            m_Logger.Information("Starting download '{FileName}' to {DestinationPath}", setupAsset.Name, destinationPath);
+
+            var downloadSuccess = await m_DownloadService.DownloadFileAsync(
+                setupAsset.DownloadUrl, 
+                destinationPath);
+
+            if (!downloadSuccess)
+            {
+                m_Logger.Error("Failed to download update file");
+                return false;
+            }
+
+            // Cleanup old files after successful download
+            m_FileManagementService.CleanupOldSetupFiles();
+
+            var confirmInstall = await MessageBoxManager.ShowConfirmationDialog(
+                "Update Downloaded", 
+                $"New version [{latestRelease.TagName}] has been downloaded.\nWould you like to install it now?");
+
+            if (confirmInstall)
+            {
+                m_Logger.Information("User confirmed installation of downloaded update");
+                return await m_InstallerService.ExecuteInstallerAsync(destinationPath);
+            }
+
+            m_Logger.Information("Update downloaded but user declined installation");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            m_Logger.Error(ex, "Failed to download and install update");
+            return false;
+        }
+    }
+}

--- a/TableCraft.Editor/Services/DownloadService.cs
+++ b/TableCraft.Editor/Services/DownloadService.cs
@@ -1,0 +1,72 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Serilog;
+
+namespace TableCraft.Editor.Services;
+
+public class DownloadService : IDownloadService
+{
+    private readonly HttpClient m_HttpClient;
+    private readonly ILogger m_Logger;
+
+    public DownloadService(HttpClient httpClient)
+    {
+        m_HttpClient = httpClient;
+        m_Logger = Log.ForContext<DownloadService>();
+    }
+
+    public async Task<bool> DownloadFileAsync(string url, string destinationPath, IProgress<double>? progress = null)
+    {
+        try
+        {
+            m_Logger.Information("Starting download from {Url} to {DestinationPath}", url, destinationPath);
+
+            var response = await m_HttpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                m_Logger.Warning("Download failed with status {StatusCode} for {Url}", response.StatusCode, url);
+                return false;
+            }
+
+            var totalBytes = response.Content.Headers.ContentLength ?? 0;
+            var directory = Path.GetDirectoryName(destinationPath);
+            
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            await using var contentStream = await response.Content.ReadAsStreamAsync();
+            await using var fileStream = new FileStream(destinationPath, FileMode.Create, FileAccess.Write);
+
+            var buffer = new byte[131072]; // 128KB buffer for better performance
+            var totalBytesRead = 0L;
+            int bytesRead;
+
+            while ((bytesRead = await contentStream.ReadAsync(buffer, 0, buffer.Length)) > 0)
+            {
+                await fileStream.WriteAsync(buffer, 0, bytesRead);
+                totalBytesRead += bytesRead;
+
+                if (totalBytes > 0 && progress != null)
+                {
+                    var progressPercentage = (double)totalBytesRead / totalBytes;
+                    progress.Report(progressPercentage);
+                }
+            }
+
+            m_Logger.Information("Download completed successfully. File saved to {DestinationPath}, Size: {Size} bytes", 
+                destinationPath, totalBytesRead);
+            
+            return true;
+        }
+        catch (Exception ex)
+        {
+            m_Logger.Error(ex, "Failed to download file from {Url} to {DestinationPath}", url, destinationPath);
+            return false;
+        }
+    }
+}

--- a/TableCraft.Editor/Services/FileManagementService.cs
+++ b/TableCraft.Editor/Services/FileManagementService.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Serilog;
+
+namespace TableCraft.Editor.Services;
+
+public class FileManagementService : IFileManagementService
+{
+    private const string UpdateFolderName = "Updates";
+    private readonly ILogger m_Logger;
+
+    public FileManagementService()
+    {
+        m_Logger = Log.ForContext<FileManagementService>();
+    }
+
+    public string GetUpdateDirectory()
+    {
+        try
+        {
+            var updatePath = Path.Combine(Program.AppDataDirectory, UpdateFolderName);
+
+            if (!Directory.Exists(updatePath))
+            {
+                Directory.CreateDirectory(updatePath);
+                m_Logger.Information("Created update directory: {UpdatePath}", updatePath);
+            }
+
+            return updatePath;
+        }
+        catch (Exception ex)
+        {
+            m_Logger.Error(ex, "Failed to get update directory");
+            return Path.GetTempPath();
+        }
+    }
+
+    public List<string> GetLocalSetupFiles()
+    {
+        try
+        {
+            var updateDirectory = GetUpdateDirectory();
+            if (!Directory.Exists(updateDirectory))
+            {
+                return new List<string>();
+            }
+
+            var setupFiles = Directory.GetFiles(updateDirectory, "*setup*.exe", SearchOption.TopDirectoryOnly)
+                .OrderByDescending(File.GetCreationTime)
+                .ToList();
+
+            m_Logger.Information("Found {Count} setup files in: {Directory}", setupFiles.Count, updateDirectory);
+            return setupFiles;
+        }
+        catch (Exception ex)
+        {
+            m_Logger.Error(ex, "Failed to get local setup files");
+            return new List<string>();
+        }
+    }
+
+    public bool CleanupOldSetupFiles(int maxFilesToKeep = 3)
+    {
+        try
+        {
+            var setupFiles = GetLocalSetupFiles();
+            if (setupFiles.Count <= maxFilesToKeep)
+            {
+                return true;
+            }
+
+            var filesToDelete = setupFiles.Skip(maxFilesToKeep).ToList();
+            var deletedCount = 0;
+
+            foreach (var file in filesToDelete)
+            {
+                try
+                {
+                    File.Delete(file);
+                    deletedCount++;
+                    m_Logger.Information("Deleted old setup file: {FilePath}", file);
+                }
+                catch (Exception ex)
+                {
+                    m_Logger.Warning(ex, "Failed to delete setup file: {FilePath}", file);
+                }
+            }
+
+            m_Logger.Information("Cleanup completed. Deleted {DeletedCount} out of {TotalCount} old setup files", 
+                deletedCount, filesToDelete.Count);
+            
+            return deletedCount == filesToDelete.Count;
+        }
+        catch (Exception ex)
+        {
+            m_Logger.Error(ex, "Failed to cleanup old setup files");
+            return false;
+        }
+    }
+
+    public string? FindLatestLocalSetup()
+    {
+        try
+        {
+            var setupFiles = GetLocalSetupFiles();
+            var latestFile = setupFiles.FirstOrDefault();
+
+            if (!string.IsNullOrEmpty(latestFile))
+            {
+                m_Logger.Information("Found latest local setup file: {FilePath}", latestFile);
+            }
+
+            return latestFile;
+        }
+        catch (Exception ex)
+        {
+            m_Logger.Error(ex, "Failed to find latest local setup file");
+            return null;
+        }
+    }
+}

--- a/TableCraft.Editor/Services/GitHubReleaseService.cs
+++ b/TableCraft.Editor/Services/GitHubReleaseService.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Serilog;
+using TableCraft.Editor.Models;
+
+namespace TableCraft.Editor.Services;
+
+public class GitHubReleaseService : IReleaseService
+{
+    private readonly HttpClient m_HttpClient;
+    private readonly ILogger m_Logger;
+
+    public GitHubReleaseService(HttpClient httpClient)
+    {
+        m_HttpClient = httpClient;
+        m_HttpClient.DefaultRequestHeaders.Add("User-Agent", "TableCraft-Editor");
+        m_Logger = Log.ForContext<GitHubReleaseService>();
+    }
+
+    public async Task<ReleaseInfo?> GetLatestReleaseAsync(string owner, string repository)
+    {
+        try
+        {
+            var url = $"https://api.github.com/repos/{owner}/{repository}/releases/latest";
+            var response = await m_HttpClient.GetAsync(url);
+            
+            if (!response.IsSuccessStatusCode)
+            {
+                m_Logger.Warning("GitHub API request failed with status {StatusCode} for '{Owner}/{Repository}'", 
+                    response.StatusCode, owner, repository);
+                return null;
+            }
+
+            var json = await response.Content.ReadAsStringAsync();
+            var releaseData = JsonSerializer.Deserialize<JsonElement>(json);
+
+            var release = new ReleaseInfo
+            {
+                TagName = releaseData.GetProperty("tag_name").GetString() ?? string.Empty,
+                Name = releaseData.GetProperty("name").GetString() ?? string.Empty,
+                Body = releaseData.GetProperty("body").GetString() ?? string.Empty,
+                IsPrerelease = releaseData.GetProperty("prerelease").GetBoolean(),
+                PublishedAt = releaseData.GetProperty("published_at").GetDateTime()
+            };
+
+            if (releaseData.TryGetProperty("assets", out var assetsElement) && assetsElement.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var assetElement in assetsElement.EnumerateArray())
+                {
+                    var asset = new ReleaseAsset
+                    {
+                        Name = assetElement.GetProperty("name").GetString() ?? string.Empty,
+                        DownloadUrl = assetElement.GetProperty("browser_download_url").GetString() ?? string.Empty,
+                        Size = assetElement.GetProperty("size").GetInt64(),
+                        ContentType = assetElement.GetProperty("content_type").GetString() ?? string.Empty
+                    };
+                    release.Assets.Add(asset);
+                }
+            }
+
+            return release;
+        }
+        catch (Exception ex)
+        {
+            m_Logger.Error(ex, "Failed to get latest release for '{Owner}/{Repository}'", owner, repository);
+            return null;
+        }
+    }
+}

--- a/TableCraft.Editor/Services/IAutoUpdateService.cs
+++ b/TableCraft.Editor/Services/IAutoUpdateService.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+
+namespace TableCraft.Editor.Services;
+
+public interface IAutoUpdateService
+{
+    Task CheckLocalDownloadedUpdatesAsync();
+    Task<bool> CheckForNewReleaseAsync();
+    Task<bool> DownloadAndInstallUpdateAsync();
+}

--- a/TableCraft.Editor/Services/IDownloadService.cs
+++ b/TableCraft.Editor/Services/IDownloadService.cs
@@ -1,0 +1,9 @@
+using System;
+using System.Threading.Tasks;
+
+namespace TableCraft.Editor.Services;
+
+public interface IDownloadService
+{
+    Task<bool> DownloadFileAsync(string url, string destinationPath, IProgress<double>? progress = null);
+}

--- a/TableCraft.Editor/Services/IFileManagementService.cs
+++ b/TableCraft.Editor/Services/IFileManagementService.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace TableCraft.Editor.Services;
+
+public interface IFileManagementService
+{
+    string GetUpdateDirectory();
+    List<string> GetLocalSetupFiles();
+    bool CleanupOldSetupFiles(int maxFilesToKeep = 3);
+    string? FindLatestLocalSetup();
+}

--- a/TableCraft.Editor/Services/IInstallerService.cs
+++ b/TableCraft.Editor/Services/IInstallerService.cs
@@ -1,0 +1,8 @@
+using System.Threading.Tasks;
+
+namespace TableCraft.Editor.Services;
+
+public interface IInstallerService
+{
+    Task<bool> ExecuteInstallerAsync(string installerPath);
+}

--- a/TableCraft.Editor/Services/IReleaseService.cs
+++ b/TableCraft.Editor/Services/IReleaseService.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+using TableCraft.Editor.Models;
+
+namespace TableCraft.Editor.Services;
+
+public interface IReleaseService
+{
+    Task<ReleaseInfo?> GetLatestReleaseAsync(string owner, string repository);
+}

--- a/TableCraft.Editor/Services/IVersionService.cs
+++ b/TableCraft.Editor/Services/IVersionService.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace TableCraft.Editor.Services;
+
+public interface IVersionService
+{
+    Version GetCurrentVersion();
+    bool IsNewerVersion(Version current, Version latest);
+    Version? ParseVersion(string versionString);
+}

--- a/TableCraft.Editor/Services/InstallerService.cs
+++ b/TableCraft.Editor/Services/InstallerService.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Serilog;
+
+namespace TableCraft.Editor.Services;
+
+public class InstallerService : IInstallerService
+{
+    private readonly ILogger m_Logger;
+
+    public InstallerService()
+    {
+        m_Logger = Log.ForContext<InstallerService>();
+    }
+
+    public async Task<bool> ExecuteInstallerAsync(string installerPath)
+    {
+        try
+        {
+            if (!File.Exists(installerPath))
+            {
+                m_Logger.Warning("Installer file not found at {InstallerPath}", installerPath);
+                return false;
+            }
+
+            m_Logger.Information("Starting installer execution: {InstallerPath}", installerPath);
+
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = installerPath,
+                UseShellExecute = true
+            };
+
+            using var process = Process.Start(startInfo);
+            if (process == null)
+            {
+                m_Logger.Error("Failed to start installer process");
+                return false;
+            }
+
+            m_Logger.Information("Installer process started with PID {ProcessId}", process.Id);
+
+            // Close current application after starting installer
+            await CloseApplicationAsync();
+            
+            return true;
+        }
+        catch (Exception ex)
+        {
+            m_Logger.Error(ex, "Failed to execute installer at {InstallerPath}", installerPath);
+            return false;
+        }
+    }
+
+    private async Task CloseApplicationAsync()
+    {
+        try
+        {
+            if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+            {
+                m_Logger.Information("Shutting down application for installer execution");
+                
+                // Allow some time for the installer to start
+                await Task.Delay(1000);
+                
+                desktop.Shutdown();
+            }
+        }
+        catch (Exception ex)
+        {
+            m_Logger.Error(ex, "Failed to close application gracefully");
+        }
+    }
+}

--- a/TableCraft.Editor/Services/MessageBoxManager.cs
+++ b/TableCraft.Editor/Services/MessageBoxManager.cs
@@ -5,12 +5,15 @@
 // Description:
 #endregion
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Threading;
 using MsBox.Avalonia.Dto;
 using MsBox.Avalonia.Enums;
+using MsBox.Avalonia.Models;
 
 namespace TableCraft.Editor.Services;
 
@@ -20,7 +23,7 @@ public static class MessageBoxManager
     public const string SuccessTitle = "Success";
     private const float m_StandardPopupWidth = 300.0f;
     private const float m_StandardPopupHeight = 180.0f;
-    
+
     public static Window? GetMainWindow()
     {
         if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
@@ -49,12 +52,19 @@ public static class MessageBoxManager
     
     public static async Task ShowStandardMessageBoxDialog(string title, string message)
     {
+        // Ensure we are on the UI thread
+        if (!Dispatcher.UIThread.CheckAccess())
+        {
+            await Dispatcher.UIThread.InvokeAsync(() => ShowStandardMessageBoxDialog(title, message));
+            return;
+        }
+
         var mainWindow = GetMainWindow();
         if (mainWindow == null)
         {
             return;
         }
-        
+
         var messageBox = MsBox.Avalonia.MessageBoxManager.GetMessageBoxStandard(
             new MessageBoxStandardParams
             {
@@ -69,14 +79,50 @@ public static class MessageBoxManager
         await messageBox.ShowWindowDialogAsync(mainWindow);
     }
 
+    public static async Task<bool> ShowConfirmationDialog(string title, string message)
+    {
+        // Ensure we are on the UI thread
+        if (!Dispatcher.UIThread.CheckAccess())
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() => ShowConfirmationDialog(title, message));
+        }
+
+        var mainWindow = GetMainWindow();
+        if (mainWindow == null)
+        {
+            return false;
+        }
+
+        var messageBox = MsBox.Avalonia.MessageBoxManager.GetMessageBoxStandard(
+            new MessageBoxStandardParams
+            {
+                ButtonDefinitions = ButtonEnum.YesNo,
+                ContentTitle = title,
+                ContentMessage = message,
+                WindowStartupLocation = WindowStartupLocation.CenterScreen,
+                MinWidth = m_StandardPopupWidth,
+                MinHeight = m_StandardPopupHeight
+            });
+
+        var result = await messageBox.ShowWindowDialogAsync(mainWindow);
+        return result == ButtonResult.Yes;
+    }
+
     public static async Task ShowCustomMarkdownMessageBoxDialog(string title, string message)
     {
+        // Ensure we are on the UI thread
+        if (!Dispatcher.UIThread.CheckAccess())
+        {
+            await Dispatcher.UIThread.InvokeAsync(() => ShowCustomMarkdownMessageBoxDialog(title, message));
+            return;
+        }
+
         var mainWindow = GetMainWindow();
         if (mainWindow == null)
         {
             return;
         }
-        
+
         var messageBox = MsBox.Avalonia.MessageBoxManager.GetMessageBoxCustom(
             new MessageBoxCustomParams
             {
@@ -89,5 +135,39 @@ public static class MessageBoxManager
             });
 
         await messageBox.ShowWindowDialogAsync(mainWindow);
+    }
+    
+    public static async Task<bool> ShowCustomMarkdownMessageBoxConfirmationDialog(string title, string message)
+    {
+        // Ensure we are on the UI thread
+        if (!Dispatcher.UIThread.CheckAccess())
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() => ShowCustomMarkdownMessageBoxConfirmationDialog(title, message));
+        }
+
+        var mainWindow = GetMainWindow();
+        if (mainWindow == null)
+        {
+            return false;
+        }
+
+        var messageBox = MsBox.Avalonia.MessageBoxManager.GetMessageBoxCustom(
+            new MessageBoxCustomParams
+            {
+                ButtonDefinitions = new ButtonDefinition[]
+                {
+                    new() {Name = "Yes", IsDefault = true, IsCancel = false},
+                    new() {Name = "No", IsDefault = false, IsCancel = true}
+                },
+                Markdown = true,
+                ContentTitle = title,
+                ContentMessage = message,
+                WindowStartupLocation = WindowStartupLocation.CenterScreen,
+                MinWidth = m_StandardPopupWidth,
+                MinHeight = m_StandardPopupHeight
+            });
+
+        var result = await messageBox.ShowWindowDialogAsync(mainWindow);
+        return result == "Yes";
     }
 }

--- a/TableCraft.Editor/Services/P4ConfigManager.cs
+++ b/TableCraft.Editor/Services/P4ConfigManager.cs
@@ -13,13 +13,7 @@ namespace TableCraft.Editor.Services;
 /// </summary>
 public class P4ConfigManager : IP4ConfigManager
 {
-    private static readonly string m_ConfigDirectory = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-        m_ConfigDirectoryName);
-
-    private static readonly string m_P4ConfigFilePath = Path.Combine(m_ConfigDirectory, m_P4ConfigFileName);
-
-    private const string m_ConfigDirectoryName = "TableCraft";
+    private static readonly string m_P4ConfigFilePath = Path.Combine(Program.AppDataDirectory, m_P4ConfigFileName);
     private const string m_P4ConfigFileName = "p4config.json";
 
     /// <summary>
@@ -94,9 +88,6 @@ public class P4ConfigManager : IP4ConfigManager
 
         try
         {
-            // ensure directory exists
-            Directory.CreateDirectory(m_ConfigDirectory);
-
             var options = new JsonSerializerOptions
             {
                 WriteIndented = true

--- a/TableCraft.Editor/Services/VersionService.cs
+++ b/TableCraft.Editor/Services/VersionService.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Reflection;
+
+namespace TableCraft.Editor.Services;
+
+public class VersionService : IVersionService
+{
+    public Version GetCurrentVersion()
+    {
+        var assembly = Assembly.GetEntryAssembly();
+        var version = assembly?.GetName().Version;
+        return version ?? new Version(1, 0, 0);
+    }
+
+    public bool IsNewerVersion(Version? current, Version? latest)
+    {
+        if (current == null || latest == null)
+        {
+            return false;
+        }
+
+        return latest.CompareTo(current) > 0;
+    }
+
+    public Version? ParseVersion(string versionString)
+    {
+        if (string.IsNullOrWhiteSpace(versionString))
+        {
+            return null;
+        }
+
+        // Remove 'v' prefix if present
+        var cleanVersion = versionString.TrimStart('v', 'V');
+        if (Version.TryParse(cleanVersion, out var version))
+        {
+            return version;
+        }
+
+        return null;
+    }
+}

--- a/TableCraft.Editor/TableCraft.Editor.csproj
+++ b/TableCraft.Editor/TableCraft.Editor.csproj
@@ -6,9 +6,9 @@
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Assets\CraftingTable_256.ico</ApplicationIcon>
-    <Version>1.4.4</Version>
-    <AssemblyVersion>1.4.4</AssemblyVersion>
-    <FileVersion>1.4.4</FileVersion>
+    <Version>1.5.0</Version>
+    <AssemblyVersion>1.5.0</AssemblyVersion>
+    <FileVersion>1.5.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TableCraft.Editor/appsettings.json
+++ b/TableCraft.Editor/appsettings.json
@@ -1,4 +1,5 @@
 ﻿{
+    "CheckForUpdates": true,
     "ConfigHomePath": "",
     "JsonHomePath": ""
 }


### PR DESCRIPTION
This pull request introduces a new automatic update feature for the TableCraft Editor application, enabling the app to check for and install updates on startup (Windows only). The update system is implemented with several new services for release management, file handling, downloading, and installation, and is integrated into the app's startup logic. Configuration options and supporting models have also been added.

**Auto-update system integration:**

* Added `AutoUpdateService` with logic to check for locally downloaded updates, query GitHub for new releases, download updates, and prompt the user to install them.
* Registered new services (`AutoUpdateService`, `ReleaseService`, `DownloadService`, `VersionService`, `FileManagementService`, `InstallerService`) in the DI container in `Program.cs`.

**Startup and configuration changes:**

* Updated `App.axaml.cs` to check the `CheckForUpdates` setting and run update checks on startup for Windows users. [[1]](diffhunk://#diff-6211c94058b54555b86371383c1b171292e256309395230b160d3b3515af804dR53-R56) [[2]](diffhunk://#diff-6211c94058b54555b86371383c1b171292e256309395230b160d3b3515af804dR71-R90)
* Added `CheckForUpdates` property to `AppSettings`, defaulting to true, and updated `appsettings.json` to include this option. [[1]](diffhunk://#diff-0994099bf4a7a175341a84d20f4fdeaaace1495c0274a6864e430a114afe4c5dR17-R21) [[2]](diffhunk://#diff-32813fd9e77efe37656b7a6e473a5f074a203432ae5d53a5a2702d8ffdcd0578R2)

**Supporting infrastructure:**

* Added `ReleaseInfo` and `ReleaseAsset` models to represent release data fetched from GitHub.
* Implemented `DownloadService` for robust file downloading with progress reporting and error handling.
* Implemented `FileManagementService` for managing update files, including finding, cleaning up, and creating update directories.
* Ensured the application data directory exists at startup to store update files. [[1]](diffhunk://#diff-d926522991e76b452bbfbe8d836d46f74fc1e9f746c8b011fdc933b7a36a3a39R20-R24) [[2]](diffhunk://#diff-d926522991e76b452bbfbe8d836d46f74fc1e9f746c8b011fdc933b7a36a3a39R93-R96)